### PR TITLE
Add basic github actions workflow

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -23,7 +23,7 @@ jobs:
         run: yarn
 
       - name: Check types
-        run: yarn tsc
+        run: yarn tsc --noEmit
 
       - name: Run jest tests
         run: yarn jest

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -1,0 +1,29 @@
+name: CI tests
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Read .nvmrc
+        run: echo ::set-output name=NVMRC::$(cat .nvmrc)
+        id: nvm
+
+      - name: Setup node
+        uses: actions/setup-node@v1
+        with:
+          node-version: "${{ steps.nvm.outputs.NVMRC }}"
+
+      - name: Install dependencies
+        run: yarn
+
+      - name: Check types
+        run: yarn tsc
+
+      - name: Run jest tests
+        run: yarn jest


### PR DESCRIPTION
Partly fixes #27 

This runs types checks and jest tests via github actions.

Running `yarn workspace-builder` is currently failing in `packages/game` due to `hex-engine-scripts` not being recognized.
Cypress tests are currently failing due to the CI running on a different platform from where the source screenshots were taken.