### PR TITLE
WIP - Add support for mouseover and mouseout

### DIFF
--- a/packages/2d/src/Components/LowLevelMouse.ts
+++ b/packages/2d/src/Components/LowLevelMouse.ts
@@ -304,9 +304,11 @@ export default function LowLevelMouse() {
     onMouseUp: (callback: Callback) => {
       storage.upCallbacks.add(useCallbackAsCurrent(callback));
     },
+    /** Registers the provided function to be called when the mouse exits the canvas. */
     onCanvasLeave: (callback: Callback) => {
       storage.outCallbacks.add(useCallbackAsCurrent(callback));
     },
+    /** Registers the provided function to be called when the mouse enters the canvas. */
     onCanvasEnter: (callback: Callback) => {
       storage.overCallbacks.add(useCallbackAsCurrent(callback));
     },

--- a/packages/2d/src/Components/LowLevelMouse.ts
+++ b/packages/2d/src/Components/LowLevelMouse.ts
@@ -72,6 +72,8 @@ export default function LowLevelMouse() {
     moveCallbacks: new Set<(event: HexMouseEvent) => void>(),
     downCallbacks: new Set<(event: HexMouseEvent) => void>(),
     upCallbacks: new Set<(event: HexMouseEvent) => void>(),
+    outCallbacks: new Set<(event: HexMouseEvent) => void>(),
+    overCallbacks: new Set<(event: HexMouseEvent) => void>(),
   };
 
   const context = useContext();
@@ -160,6 +162,14 @@ export default function LowLevelMouse() {
     };
   };
 
+  const handleMouseOut = () => {
+    storage.outCallbacks.forEach((callback) => callback(event));
+  };
+
+  const handleMouseOver = () => {
+    storage.overCallbacks.forEach((callback) => callback(event));
+  };
+
   let isTouching = false;
   const handleTouchStart = (ev: TouchEvent) => {
     ev.preventDefault();
@@ -234,6 +244,8 @@ export default function LowLevelMouse() {
     canvas.addEventListener("mousemove", handleMouseMove);
     canvas.addEventListener("mousedown", handleMouseDown);
     canvas.addEventListener("mouseup", handleMouseUp);
+    canvas.addEventListener("mouseover", handleMouseOver);
+    canvas.addEventListener("mouseout", handleMouseOut);
 
     canvas.addEventListener("touchstart", handleTouchStart);
     canvas.addEventListener("touchmove", handleTouchMove);
@@ -275,6 +287,12 @@ export default function LowLevelMouse() {
     /** Registers the provided function to be called when any button on the mouse is released. */
     onMouseUp: (callback: (event: HexMouseEvent) => void) => {
       storage.upCallbacks.add(useCallbackAsCurrent(callback));
+    },
+    onMouseOut: (callback: (event: HexMouseEvent) => void) => {
+      storage.outCallbacks.add(useCallbackAsCurrent(callback));
+    },
+    onMouseOver: (callback: (event: HexMouseEvent) => void) => {
+      storage.overCallbacks.add(useCallbackAsCurrent(callback));
     },
   };
 }

--- a/packages/2d/src/Components/LowLevelMouse.ts
+++ b/packages/2d/src/Components/LowLevelMouse.ts
@@ -288,10 +288,10 @@ export default function LowLevelMouse() {
     onMouseUp: (callback: (event: HexMouseEvent) => void) => {
       storage.upCallbacks.add(useCallbackAsCurrent(callback));
     },
-    onMouseOut: (callback: (event: HexMouseEvent) => void) => {
+    onCanvasLeave: (callback: (event: HexMouseEvent) => void) => {
       storage.outCallbacks.add(useCallbackAsCurrent(callback));
     },
-    onMouseOver: (callback: (event: HexMouseEvent) => void) => {
+    onCanvasEnter: (callback: (event: HexMouseEvent) => void) => {
       storage.overCallbacks.add(useCallbackAsCurrent(callback));
     },
   };

--- a/packages/2d/src/Components/Mouse.ts
+++ b/packages/2d/src/Components/Mouse.ts
@@ -39,9 +39,11 @@ export default function Mouse({
     onClickCallbacks: new Set<Callback>(),
     onRightClickCallbacks: new Set<Callback>(),
     onMiddleClickCallbacks: new Set<Callback>(),
+    onOutCallbacks: new Set<Callback>(),
+    onOverCallbacks: new Set<Callback>(),
   };
 
-  const { onMouseDown, onMouseUp } = useNewComponent(LowLevelMouse);
+  const { onMouseDown, onMouseUp, onMouseOut, onMouseOver } = useNewComponent(LowLevelMouse);
   const mousePosition = useNewComponent(() =>
     MousePosition({ entity, geometry })
   );
@@ -93,6 +95,14 @@ export default function Mouse({
     }
   });
 
+  onMouseOut((event) => {
+    storage.onOutCallbacks.forEach((callback) => callback(event));
+  });
+
+  onMouseOver((event) => {
+    storage.onOverCallbacks.forEach((callback) => callback(event));
+  });
+
   const callbackSetters = {
     onDown(callback: (event: HexMouseEvent) => void) {
       storage.onDownCallbacks.add(useCallbackAsCurrent(callback));
@@ -108,6 +118,12 @@ export default function Mouse({
     },
     onMiddleClick(callback: (event: HexMouseEvent) => void) {
       storage.onMiddleClickCallbacks.add(useCallbackAsCurrent(callback));
+    },
+    onOut(callback: (event: HexMouseEvent) => void) {
+      storage.onOutCallbacks.add(useCallbackAsCurrent(callback));
+    },
+    onOver(callback: (event: HexMouseEvent) => void) {
+      storage.onOverCallbacks.add(useCallbackAsCurrent(callback));
     },
   };
 
@@ -173,6 +189,16 @@ export default function Mouse({
      */
     get onLeave() {
       return mousePosition.onLeave;
+    },
+
+    // TODO: explain
+    get onOut() {
+      return callbackSetters.onOut;
+    },
+
+    // TODO: explain
+    get onOver() {
+      return callbackSetters.onOver;
     },
 
     /**

--- a/packages/2d/src/Components/Mouse.ts
+++ b/packages/2d/src/Components/Mouse.ts
@@ -39,11 +39,9 @@ export default function Mouse({
     onClickCallbacks: new Set<Callback>(),
     onRightClickCallbacks: new Set<Callback>(),
     onMiddleClickCallbacks: new Set<Callback>(),
-    onOutCallbacks: new Set<Callback>(),
-    onOverCallbacks: new Set<Callback>(),
   };
 
-  const { onMouseDown, onMouseUp, onMouseOut, onMouseOver } = useNewComponent(LowLevelMouse);
+  const { onMouseDown, onMouseUp } = useNewComponent(LowLevelMouse);
   const mousePosition = useNewComponent(() =>
     MousePosition({ entity, geometry })
   );
@@ -95,14 +93,6 @@ export default function Mouse({
     }
   });
 
-  onMouseOut((event) => {
-    storage.onOutCallbacks.forEach((callback) => callback(event));
-  });
-
-  onMouseOver((event) => {
-    storage.onOverCallbacks.forEach((callback) => callback(event));
-  });
-
   const callbackSetters = {
     onDown(callback: (event: HexMouseEvent) => void) {
       storage.onDownCallbacks.add(useCallbackAsCurrent(callback));
@@ -118,12 +108,6 @@ export default function Mouse({
     },
     onMiddleClick(callback: (event: HexMouseEvent) => void) {
       storage.onMiddleClickCallbacks.add(useCallbackAsCurrent(callback));
-    },
-    onOut(callback: (event: HexMouseEvent) => void) {
-      storage.onOutCallbacks.add(useCallbackAsCurrent(callback));
-    },
-    onOver(callback: (event: HexMouseEvent) => void) {
-      storage.onOverCallbacks.add(useCallbackAsCurrent(callback));
     },
   };
 
@@ -189,16 +173,6 @@ export default function Mouse({
      */
     get onLeave() {
       return mousePosition.onLeave;
-    },
-
-    // TODO: explain
-    get onOut() {
-      return callbackSetters.onOut;
-    },
-
-    // TODO: explain
-    get onOver() {
-      return callbackSetters.onOver;
     },
 
     /**

--- a/packages/create/template/src/Draggable.ts
+++ b/packages/create/template/src/Draggable.ts
@@ -36,7 +36,7 @@ export default function Draggable(geometry: ReturnType<typeof Geometry>) {
     }
   });
 
-  const onUpHandler = (e) => {
+  const onUpHandler = () => {
     if (physics) {
       physics.setStatic(originalStatic);
     }

--- a/packages/create/template/src/Draggable.ts
+++ b/packages/create/template/src/Draggable.ts
@@ -34,10 +34,12 @@ export default function Draggable(geometry: ReturnType<typeof Geometry>) {
     }
   });
 
-  mouse.onUp(() => {
+  const onUpHandler = (e) => {
     if (physics) {
       physics.setStatic(originalStatic);
     }
     isDragging = false;
-  });
+  };
+  mouse.onUp(onUpHandler);
+  mouse.onOut(onUpHandler);
 }

--- a/packages/create/template/src/Draggable.ts
+++ b/packages/create/template/src/Draggable.ts
@@ -6,6 +6,7 @@ import {
   Physics,
   Mouse,
   Vector,
+  LowLevelMouse,
 } from "@hex-engine/2d";
 
 export default function Draggable(geometry: ReturnType<typeof Geometry>) {
@@ -14,6 +15,7 @@ export default function Draggable(geometry: ReturnType<typeof Geometry>) {
   const physics = useEntity().getComponent(Physics.Body);
 
   const mouse = useNewComponent(Mouse);
+  const { onCanvasLeave } = useNewComponent(LowLevelMouse);
 
   let originalStatic = false;
   let isDragging = false;
@@ -41,5 +43,5 @@ export default function Draggable(geometry: ReturnType<typeof Geometry>) {
     isDragging = false;
   };
   mouse.onUp(onUpHandler);
-  mouse.onOut(onUpHandler);
+  onCanvasLeave(onUpHandler);
 }


### PR DESCRIPTION
onEnter and onLeave in the Mouse component are calculated and will not trigger the same way the low level mouseover and mouseout do. For this reason they won't work to fix issue #32.

This PR adds support to those two low level events and updates the example site with a fix for #32.


