### PR TITLE
Fixing link in @hex-engine/2d README

### DIFF
--- a/packages/2d/README.md
+++ b/packages/2d/README.md
@@ -10,7 +10,7 @@ It includes:
 - Components that make it easy to work with [Aseprite](https://www.aseprite.org/), [Tiled](https://www.mapeditor.org/), and [BMFont](https://www.angelcode.com/products/bmfont/) assets
 - Components that make it easy to work with mouse, keyboard, and gamepad input
 - Components for a 2D Physics Engine ([matter.js](https://brm.io/matter-js/))
-- Components and hooks for working with the Web Audio context and generating procedural sound via `[modal-synthesis](https://www.npmjs.com/package/modal-synthesis)`
+- Components and hooks for working with the Web Audio context and generating procedural sound via [modal-synthesis](https://www.npmjs.com/package/modal-synthesis)
 - And much, much more
 
 For more information, please check the main README for [Hex Engine](https://github.com/suchipi/hex-engine).


### PR DESCRIPTION
Removed backtick from modal-synthesis link.