### PR TITLE
Allow CanvasGradient as a font color

### DIFF
--- a/packages/2d/src/Components/SystemFont.ts
+++ b/packages/2d/src/Components/SystemFont.ts
@@ -10,7 +10,7 @@ export default function SystemFont({
 }: {
   name: string;
   size: number;
-  color?: void | string;
+  color?: void | string | CanvasGradient;
 }) {
   useType(SystemFont);
 


### PR DESCRIPTION
It's just a typescript type change, it already works when cast as `any`.

Can be tested with this before drawing:

```
const gradient = context.createLinearGradient(0, 0, 100, 0);
gradient.addColorStop(0," magenta");
gradient.addColorStop(0.5, "blue");
gradient.addColorStop(1, "red");
font.color = gradient;
```