### PR TITLE
Add Entity.takeChild(Entity)

### DIFF
--- a/packages/core/src/Entity.ts
+++ b/packages/core/src/Entity.ts
@@ -148,4 +148,9 @@ export default class Entity implements EntityInterface {
 
     return ancestors;
   }
+
+  takeChild(entity: Entity) {
+    entity.parent?._removeChild(entity);
+    this._addChild(entity);
+  }
 }

--- a/packages/core/src/Interface.ts
+++ b/packages/core/src/Interface.ts
@@ -45,6 +45,11 @@ export interface Entity {
    * parent) will be last in the Array.
    */
   ancestors(): Array<Entity>;
+  
+  /**
+   * Transfer the ownership of the Entity from its parent to this Entity.
+   */
+  takeChild(entity: Entity): void;
 
   /**
    * All the Component instances that are on this Entity.

--- a/packages/website/docs/api-core.md
+++ b/packages/website/docs/api-core.md
@@ -124,6 +124,15 @@ Disable all [`Component`]s on this Entity and its [descendants][`entity.descenda
 
 Use the [`useEnableDisable`] hook to specify what happens when a [`Component`] is enabled or disabled.
 
+##### takeChild
+
+> Available since version: Unreleased
+
+`takeChild(entity: Entity)`
+
+Transfer the ownership of `entity` to this Entity, so that it becomes the 
+[parent][`entity.parent`] of `entity`.
+
 ##### destroy
 
 > Available since version: 0.1.2


### PR DESCRIPTION
Add an official API to change the parent of an entity.

Current use case: 

I want my game to handle window resizes gracefully. So I created a `CanvasCenter` component with a geometry that always updates to the canvas' center:

```ts
export default function CanvasCenter() {
  useType(CanvasCenter);

  const geo = useNewComponent(() => Geometry({shape: new Polygon([])}));

  useUpdate(() => {
    const canvas = useRootEntity().getComponent(Canvas)!;

    geo.position.mutateInto({x: canvas.element.width/2, y: canvas.element.height/2});
  });
}
```

In my `Root` component, I create all my components as usual, but with their coordinates centered around (0, 0) instead of `canvasCenter`.

Then at the end of my `Root` component function, I do this:

```ts
  // Transfer everything to the canvas center
  const center = useChild(CanvasCenter);
  const root = useEntity();
  for (const entity of root.children) {
    if (entity !== center) {
      entity.parent = center;
      center.children.add(entity);
      root.children.delete(entity);
    }
  }
```

This is risky if the internals of hex-engine change, and not guaranteed to always work in the future.

It would be nice to have an official API, and do this instead:

```ts
  // Transfer everything to the canvas center
  const center = useChild(CanvasCenter);
  const root = useEntity();
  for (const entity of root.children) {
    if (entity !== center) {
      center.takeChild(entity);
    }
  }
```