### PR TITLE
Make shape optional in Geometry()

### DIFF
--- a/packages/2d/src/Components/Geometry.ts
+++ b/packages/2d/src/Components/Geometry.ts
@@ -13,18 +13,17 @@ import {
  *
  * You should only have one `Geometry` component per `Entity`.
  */
-function Geometry({
-  shape = new Polygon([]),
+function Geometry<S extends Shape = Polygon>({
+  shape,
   position = new Vector(0, 0),
   rotation = 0,
   scale = new Vector(1, 1),
 }: {
-  shape?: Shape;
+  shape?: S;
   position?: Vector | undefined;
   rotation?: number | undefined;
   scale?: Vector | undefined;
 } = {
-  shape: new Polygon([]),
   position: new Vector(0, 0),
   rotation: 0,
   scale: new Vector(1, 1),
@@ -34,7 +33,7 @@ function Geometry({
   const transforms = useEntityTransforms();
 
   const geometry = {
-    shape,
+    shape: shape ?? new Polygon([]),
     position,
     rotation,
     scale,

--- a/packages/2d/src/Components/Geometry.ts
+++ b/packages/2d/src/Components/Geometry.ts
@@ -1,5 +1,5 @@
 import { useType } from "@hex-engine/core";
-import { Vector, Shape } from "../Models";
+import { Vector, Shape, Polygon } from "../Models";
 import {
   useInspectorHoverOutline,
   useInspectorSelectEntity,
@@ -13,16 +13,21 @@ import {
  *
  * You should only have one `Geometry` component per `Entity`.
  */
-function Geometry<S extends Shape>({
-  shape,
+function Geometry({
+  shape = new Polygon([]),
   position = new Vector(0, 0),
   rotation = 0,
   scale = new Vector(1, 1),
 }: {
-  shape: S;
+  shape?: Shape;
   position?: Vector | undefined;
   rotation?: number | undefined;
   scale?: Vector | undefined;
+} = {
+  shape: new Polygon([]),
+  position: new Vector(0, 0),
+  rotation: 0,
+  scale: new Vector(1, 1),
 }) {
   useType(Geometry);
 


### PR DESCRIPTION
I've encountered twice the situation where I don't need the shape to be specified in my geometry:

- When using a component as an interpolation destination, i.e. I want to transform an entity's geometry over time to have the same rotation / position / scale as my interpolation, cf the `Attractor` in #46 
- When I use a component as a parent in order to "group" them in order to translate them (like a `<g>` svg tag), cf the `CanvasCenter` in #49 

This PR is a quality of life improvement, to be able to just do `useNewComponent(Geometry);`