### PR TITLE
scripts(build): Configurable entry point

### DIFF
--- a/packages/scripts/src/makeWebpackConfig.ts
+++ b/packages/scripts/src/makeWebpackConfig.ts
@@ -29,7 +29,7 @@ export default (mode: "production" | "development" | "test") => {
 
     mode: mode === "test" ? "development" : mode,
 
-    entry: [packageDir("./src/polyfills"), localDir("./src/index.ts")],
+    entry: [packageDir("./src/polyfills"), localDir(process.env.HEX_ENGINE_ENTRY_POINT || "./src/index.ts")],
     output: {
       path: localDir("dist"),
     },


### PR DESCRIPTION
I want to be able to specify the entry point used for the build, either through a configuration file, a command line argument, or as in this commit, an environment variable.

The reason is for developing I run the program as standalone, but I want to ship it as a library / an umd module that adds a variable in the global scope.