### PR TITLE
Fix localStorage issue?

### DIFF
--- a/packages/inspector/src/index.tsx
+++ b/packages/inspector/src/index.tsx
@@ -35,9 +35,17 @@ interface StateHolder {
   collapseTree: () => void;
 }
 
-const initialInspectorTree = localStorage.inspectorTree
-  ? JSON.parse(localStorage.inspectorTree)
-  : { root: {} };
+// Chrome throws an error when localStorage is not available, even if all you do
+// is check if it's undefined. So this approach is needed.
+const initialInspectorTree = (() => {
+  try {
+    return localStorage.inspectorTree
+      ? JSON.parse(localStorage.inspectorTree)
+      : { root: {} };
+  } catch (err) {
+    return { root: {} };
+  }
+})();
 
 function saveTree(tree: any) {
   localStorage.inspectorTree = JSON.stringify(tree);


### PR DESCRIPTION
Fix #54 . 

Alternative would be to not at all require the inspector in production builds (would maybe reduce package size too?), maybe by aliasing it to an empty module in the webpack configuration.